### PR TITLE
fix: changed minute padding procedure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ searchForm.addEventListener("submit", changeCity);
 let currentTime = new Date();
 let hour = currentTime.getHours();
 let minutes = currentTime.getMinutes();
-let formattedMinutes = minutes < 10 ? "0" + minutes : minutes;
+let formattedMinutes = minutes.padStart(2, '0');
 
 let daysOfTheWeek = [
   "Sunday",


### PR DESCRIPTION
Padding appears to be done manually and with type inconsistencies (`formattedMinutes` could be both `String` and `int` depending on the ternary operator).

This way it's more cohesive and uses the standard API to do it.